### PR TITLE
Harden build-scan latest release lookup

### DIFF
--- a/.github/workflows/build-scan.yaml
+++ b/.github/workflows/build-scan.yaml
@@ -114,7 +114,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           # Get the latest release tag
-          LATEST_TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name' 2>/dev/null || true)
+          LATEST_TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name // empty' 2>/dev/null || true)
           if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ] || echo "$LATEST_TAG" | grep -qE 'Not Found|\{"message\"'; then
             echo "No published version found, skipping baseline comparison"
             echo "has_baseline=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- use robust release lookup ()
- guard against non-tag payloads before baseline download
- prevent false failures when no release exists yet
